### PR TITLE
new Processor constructor for Loader based plugins

### DIFF
--- a/src/main/java/me/gleeming/command/paramter/Processor.java
+++ b/src/main/java/me/gleeming/command/paramter/Processor.java
@@ -14,10 +14,20 @@ public abstract class Processor<T> {
 
     private final Class<?> type;
 
+
     @SneakyThrows
     public Processor() {
+        // can cause ClassNotFoundException with Loader based plugins
         Type type = ((ParameterizedType) this.getClass().getGenericSuperclass()).getActualTypeArguments()[0];
         this.type = Class.forName(type.getTypeName());
+        ParamProcessor.createProcessor(this);
+    }
+
+    // This constructor makes it easier for Loader based plugins to create processors
+    // ensures that the Processor constructor has a reference to the type, and doesn't need to use reflection to determine the class.
+    @SneakyThrows
+    public Processor(Class<?> type) {
+        this.type = type;
         ParamProcessor.createProcessor(this);
     }
 


### PR DESCRIPTION
I ran into issues with my loader and security system where processors would throw ClassNotFoundException for their types.

Added new constructor ensures that the Processor has a reference to the type, and doesn't need to use reflection to determine the class.